### PR TITLE
added rtg-math.vari to .asd

### DIFF
--- a/cepl.examples.asd
+++ b/cepl.examples.asd
@@ -6,9 +6,11 @@
   :license "GPL V3"
   #+asdf-unicode :encoding #+asdf-unicode :utf-8
   :serial t
-  :depends-on (#:cepl.sdl2 #:dendrite #:skitter #:cepl.skitter.sdl2
-                           #:livesupport #:classimp #:split-sequence
-                           #:dirt #:temporal-functions)
+  :depends-on (#:cepl.sdl2
+               #:rtg-math.vari
+               #:dendrite #:skitter #:cepl.skitter.sdl2
+               #:livesupport #:classimp #:split-sequence
+               #:dirt #:temporal-functions)
   :components ((:file "package")
                (:file "examples/helpers/examples-data")
                (:file "examples/helpers/camera")


### PR DESCRIPTION
rtg-math dependency was removed from cepl in https://github.com/cbaggers/cepl/commit/66b9978f9f1dba447a0a784da54aa43a4171e4fa
